### PR TITLE
Multitap support

### DIFF
--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -30,23 +30,30 @@ class InputRecording
 public:
 	InputRecording();
 
-	void ControllerInterrupt(u8 const &data, u8 const &port, u16 const &bufCount, u8 buf[]);
+	void ControllerInterrupt(u8 const &data, u8 const &port, u8 const &slot, u16 const &bufCount, u8 buf[]);
 
 	void RecordModeToggle();
 
 	INPUT_RECORDING_MODE GetModeState();
 	InputRecordingFile & GetInputRecordingData();
-	bool IsInterruptFrame();
 
 	void Stop();
-	void Create(wxString filename, bool fromSaveState, wxString authorName);
-	void Play(wxString filename, bool fromSaveState);
+	bool Create(wxString filename, bool fromSaveState, wxString authorName, bool (&slots)[2][4]);
+	bool Play(wxString filename);
 
-	void SetVirtualPadPtr(VirtualPad *ptr, int const port);
+	void SetVirtualPadPtr(VirtualPad *ptr, const u8 port, const u8 slot);
+	void SetMultitapBuffer(const bool port1, const bool port2);
+	bool GetMultitapBuffer(const u8 port);
 
 private:
-    static const int CONTROLLER_PORT_ONE = 0;
-    static const int CONTROLLER_PORT_TWO = 1;
+	static const int CONTROLLER_PORT_ONE = 0;
+	static const int CONTROLLER_PORT_TWO = 1;
+	static const int CONTROLLER_SLOT_A = 0;
+	static const int CONTROLLER_SLOT_B = 1;
+	static const int CONTROLLER_SLOT_C = 2;
+	static const int CONTROLLER_SLOT_D = 3;
+	//Holds pre-recording multitap settings 
+	bool multitap_Buffer[2];
 
 	// 0x42 is the magic number to indicate the default controller read query
 	// See - Lilypad.cpp::PADpoll - https://github.com/PCSX2/pcsx2/blob/v1.5.0-dev/plugins/LilyPad/LilyPad.cpp#L1193
@@ -61,10 +68,10 @@ private:
 	bool fInterruptFrame = false;
 
 	// Controller Data
-	PadData *padData[2];
+	PadData *padData[2][4];
 
 	// VirtualPads
-	VirtualPad *virtualPads[2];
+	VirtualPad *virtualPads[2][4];
 };
 
 extern InputRecording g_InputRecording;

--- a/pcsx2/Recording/NewRecordingFrame.cpp
+++ b/pcsx2/Recording/NewRecordingFrame.cpp
@@ -23,16 +23,28 @@ NewRecordingFrame::NewRecordingFrame(wxWindow *parent)
 	: wxDialog(parent, wxID_ANY, "New Input Recording", wxDefaultPosition, wxDefaultSize, wxSTAY_ON_TOP | wxCAPTION)
 {
 	wxPanel *panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _("panel"));
+	m_empty = new wxStaticText(panel, wxID_ANY, _(""), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
 
-	wxFlexGridSizer *fgs = new wxFlexGridSizer(4, 2, 20, 20);
+	wxFlexGridSizer *fgs = new wxFlexGridSizer(10, 2, 20, 20);
 	wxBoxSizer *container = new wxBoxSizer(wxVERTICAL);
 
 	m_fileLabel = new wxStaticText(panel, wxID_ANY, _("File Path"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
 	m_authorLabel = new wxStaticText(panel, wxID_ANY, _("Author"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
-	m_fromLabel = new wxStaticText(panel, wxID_ANY, _("Record From"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+	m_ControllerLabel = new wxStaticText(panel, wxID_ANY, _("Controllers"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+	m_SlotLabel_1 = new wxStaticText(panel, wxID_ANY, _("Port 1"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
+	m_SlotLabel_2 = new wxStaticText(panel, wxID_ANY, _("Port 2"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
 
 	m_filePicker = new wxFilePickerCtrl(panel, MenuIds_New_Recording_Frame_File, wxEmptyString, "File", L"p2m2 file(*.p2m2)|*.p2m2", wxDefaultPosition, wxDefaultSize, wxFLP_SAVE | wxFLP_OVERWRITE_PROMPT | wxFLP_USE_TEXTCTRL);
 	m_authorInput = new wxTextCtrl(panel, MenuIds_New_Recording_Frame_Author, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+	m_SlotCheck[0][0] = new wxCheckBox(panel, MenuIds_New_Recording_Frame_Slot_1A, _("1A"), wxDefaultPosition, wxDefaultSize);
+	m_SlotCheck[1][0] = new wxCheckBox(panel, MenuIds_New_Recording_Frame_Slot_2A, _("2A"), wxDefaultPosition, wxDefaultSize);
+	m_SlotCheck[0][1] = new wxCheckBox(panel, MenuIds_New_Recording_Frame_Slot_1B, _("1B"), wxDefaultPosition, wxDefaultSize);
+	m_SlotCheck[1][1] = new wxCheckBox(panel, MenuIds_New_Recording_Frame_Slot_2B, _("2B"), wxDefaultPosition, wxDefaultSize);
+	m_SlotCheck[0][2] = new wxCheckBox(panel, MenuIds_New_Recording_Frame_Slot_1C, _("1C"), wxDefaultPosition, wxDefaultSize);
+	m_SlotCheck[1][2] = new wxCheckBox(panel, MenuIds_New_Recording_Frame_Slot_2C, _("2C"), wxDefaultPosition, wxDefaultSize);
+	m_SlotCheck[0][3] = new wxCheckBox(panel, MenuIds_New_Recording_Frame_Slot_1D, _("1D"), wxDefaultPosition, wxDefaultSize);
+	m_SlotCheck[1][3] = new wxCheckBox(panel, MenuIds_New_Recording_Frame_Slot_2D, _("2D"), wxDefaultPosition, wxDefaultSize);
+	m_fromLabel = new wxStaticText(panel, wxID_ANY, _("Record From"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTER);
 	wxArrayString choices;
 	choices.Add("Current Frame");
 	choices.Add("Power-On");
@@ -47,6 +59,21 @@ NewRecordingFrame::NewRecordingFrame(wxWindow *parent)
 
 	fgs->Add(m_authorLabel, 1);
 	fgs->Add(m_authorInput, 1, wxEXPAND);
+
+	fgs->Add(m_ControllerLabel, 2);
+	fgs->Add(m_empty, 1); //Empty spot
+
+	fgs->Add(m_SlotLabel_1, 1);
+	fgs->Add(m_SlotLabel_2, 1);
+
+	fgs->Add(m_SlotCheck[0][0], 1);
+	fgs->Add(m_SlotCheck[1][0], 1);
+	fgs->Add(m_SlotCheck[0][1], 1);
+	fgs->Add(m_SlotCheck[1][1], 1);
+	fgs->Add(m_SlotCheck[0][2], 1);
+	fgs->Add(m_SlotCheck[1][2], 1);
+	fgs->Add(m_SlotCheck[0][3], 1);
+	fgs->Add(m_SlotCheck[1][3], 1);
 
 	fgs->Add(m_fromLabel, 1);
 	fgs->Add(m_fromChoice, 1, wxEXPAND);
@@ -80,4 +107,20 @@ int NewRecordingFrame::GetFrom() const
 {
 	return m_fromChoice->GetSelection();
 }
+
+//Grabs slot values from the window and inserts into the array provided
+void NewRecordingFrame::RetrieveSlots(bool (&slotBuf)[2][4]) const
+{
+	//Port 1
+	slotBuf[0][0] = m_SlotCheck[0][0]->GetValue();
+	slotBuf[0][1] = m_SlotCheck[0][1]->GetValue();
+	slotBuf[0][2] = m_SlotCheck[0][2]->GetValue();
+	slotBuf[0][3] = m_SlotCheck[0][3]->GetValue();
+	//Port 2
+	slotBuf[1][0] = m_SlotCheck[1][0]->GetValue();
+	slotBuf[1][1] = m_SlotCheck[1][1]->GetValue();
+	slotBuf[1][2] = m_SlotCheck[1][2]->GetValue();
+	slotBuf[1][3] = m_SlotCheck[1][3]->GetValue();
+}
+
 #endif

--- a/pcsx2/Recording/NewRecordingFrame.h
+++ b/pcsx2/Recording/NewRecordingFrame.h
@@ -24,7 +24,15 @@ enum MenuIds_New_Recording_Frame
 {
 	MenuIds_New_Recording_Frame_File = 0,
 	MenuIds_New_Recording_Frame_Author,
-	MenuIds_New_Recording_Frame_From
+	MenuIds_New_Recording_Frame_From,
+	MenuIds_New_Recording_Frame_Slot_1A,
+	MenuIds_New_Recording_Frame_Slot_1B,
+	MenuIds_New_Recording_Frame_Slot_1C,
+	MenuIds_New_Recording_Frame_Slot_1D,
+	MenuIds_New_Recording_Frame_Slot_2A,
+	MenuIds_New_Recording_Frame_Slot_2B,
+	MenuIds_New_Recording_Frame_Slot_2C,
+	MenuIds_New_Recording_Frame_Slot_2D
 };
 
 // The Dialog to pop-up when recording a new movie
@@ -36,14 +44,20 @@ public:
 	wxString GetFile() const;
 	wxString GetAuthor() const;
 	int GetFrom() const;
+	void RetrieveSlots(bool (&slotBuf)[2][4]) const;
 
 private:
+	wxStaticText* m_empty;
 	wxStaticText *m_fileLabel;
 	wxFilePickerCtrl *m_filePicker;
 	wxStaticText *m_authorLabel;
 	wxTextCtrl *m_authorInput;
-	wxStaticText *m_fromLabel;
 	wxChoice *m_fromChoice;
+	wxStaticText* m_ControllerLabel;
+	wxStaticText* m_SlotLabel_1;
+	wxStaticText* m_SlotLabel_2;
+	wxCheckBox* m_SlotCheck[2][4];
+	wxStaticText* m_fromLabel;
 	wxButton *m_startRecording;
 	wxButton *m_cancelRecording;
 };

--- a/pcsx2/Recording/PadData.cpp
+++ b/pcsx2/Recording/PadData.cpp
@@ -189,16 +189,16 @@ wxString PadData::RawPadBytesToString(int start, int end)
 	return str;
 }
 
-void PadData::LogPadData(u8 const &port) {
+void PadData::LogPadData(u8 const &port, u8 const &slot) {
 	wxString pressedBytes = RawPadBytesToString(0, 2);
 	wxString rightAnalogBytes = RawPadBytesToString(2, 4);
 	wxString leftAnalogBytes = RawPadBytesToString(4, 6);
 	wxString pressureBytes = RawPadBytesToString(6, 17);
     wxString fullLog =
-        wxString::Format("[PAD %d] Raw Bytes: Pressed = [%s]\n", port + 1, pressedBytes) +
-        wxString::Format("[PAD %d] Raw Bytes: Right Analog = [%s]\n", port + 1, rightAnalogBytes) +
-        wxString::Format("[PAD %d] Raw Bytes: Left Analog = [%s]\n", port + 1, leftAnalogBytes) +
-        wxString::Format("[PAD %d] Raw Bytes: Pressure = [%s]\n", port + 1, pressureBytes);
+        wxString::Format("[PAD %d%c] Raw Bytes: Pressed = [%s]\n", port + 1, 'A' + slot, pressedBytes) +
+        wxString::Format("[PAD %d%c] Raw Bytes: Right Analog = [%s]\n", port + 1, 'A' + slot, rightAnalogBytes) +
+        wxString::Format("[PAD %d%c] Raw Bytes: Left Analog = [%s]\n", port + 1, 'A' + slot, leftAnalogBytes) +
+        wxString::Format("[PAD %d%c] Raw Bytes: Pressure = [%s]\n", port + 1, 'A' + slot, pressureBytes);
 	controlLog(fullLog);
 }
 

--- a/pcsx2/Recording/PadData.h
+++ b/pcsx2/Recording/PadData.h
@@ -92,7 +92,7 @@ public:
 	u8 PollControllerData(u16 bufIndex);
 
 	// Prints current PadData to the Controller Log filter which disabled by default
-    void LogPadData(u8 const &port);
+    void LogPadData(u8 const &port, u8 const &slot);
 
 private:
 	struct ButtonResolver

--- a/pcsx2/Recording/VirtualPad/VirtualPad.cpp
+++ b/pcsx2/Recording/VirtualPad/VirtualPad.cpp
@@ -48,7 +48,7 @@
 
 // TODO - Store position of frame in an (possibly the main) .ini file
 
-VirtualPad::VirtualPad(wxWindow* parent, wxWindowID id, const wxString& title, int controllerPort, const wxPoint& pos, const wxSize& size, long style) :
+VirtualPad::VirtualPad(wxWindow* parent, wxWindowID id, const wxString& title, u8 controllerPort, u8 controllerSlot, const wxPoint& pos, const wxSize& size, long style) :
 	wxFrame(parent, id, title, pos, size, wxDEFAULT_FRAME_STYLE)
 {
 	// Images at 1.00 scale are designed to work well on HiDPI (4k) at 150% scaling (default recommended setting on windows)
@@ -109,7 +109,7 @@ VirtualPad::VirtualPad(wxWindow* parent, wxWindowID id, const wxString& title, i
 
 	// Finalize layout
 	SetIcons(wxGetApp().GetIconBundle());
-	SetTitle(wxString::Format("Virtual Pad - Port %d", controllerPort + 1));
+	SetTitle(wxString::Format("Virtual Pad - Port %d : Slot %d", controllerPort + 1, controllerSlot + 1));
 	SetBackgroundColour(*wxWHITE);
 	SetBackgroundStyle(wxBG_STYLE_PAINT);
     // This window does not allow for resizing for sake of simplicity: all images are scaled initially and stored, ready to be rendered

--- a/pcsx2/Recording/VirtualPad/VirtualPad.h
+++ b/pcsx2/Recording/VirtualPad/VirtualPad.h
@@ -35,7 +35,7 @@
 class VirtualPad : public wxFrame
 {
 public:
-	VirtualPad(wxWindow *parent, wxWindowID id, const wxString& title, int controllerPort, 
+	VirtualPad(wxWindow *parent, wxWindowID id, const wxString& title, u8 controllerPort, u8 controllerSlot, 
 		const wxPoint &pos = wxDefaultPosition, const wxSize &size = wxDefaultSize, long style = wxDEFAULT_FRAME_STYLE);
 	// Updates the VirtualPad's data if necessary, as well as updates the provided PadData if the VirtualPad overrides it
 	// - PadData will not be updated if ReadOnly mode is set

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -224,7 +224,6 @@ SIO_WRITE sioWriteController(u8 data)
 			//Note: this is a file is currently loaded
 			else if (sio.slot[sio.port] > 0)
 			{
-				recordingConLog(wxString::Format("Y%d-%d\n", sio.port, sio.slot[sio.port]));
 				DEVICE_UNPLUGGED();
 				sio.buf[0] = 0x00;
 				siomode = SIO_DUMMY;

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -215,7 +215,19 @@ SIO_WRITE sioWriteController(u8 data)
 #ifndef DISABLE_RECORDING
 		if (g_Conf->EmuOptions.EnableRecordingTools)
 		{
-			g_InputRecording.ControllerInterrupt(data, sio.port, sio.bufCount, sio.buf);
+			//If a recoding file isn't currently loaded or if the current port & slot is active, pull the data
+			if (g_InputRecording.GetModeState() == INPUT_RECORDING_MODE_NONE || g_InputRecordingData.ActiveSlot(sio.port, sio.slot[sio.port]))
+			{
+				g_InputRecording.ControllerInterrupt(data, sio.port, sio.slot[sio.port], sio.bufCount, sio.buf);
+			}
+			//If the port isn't in use at all or if the slot for said port is not the first slot, act as if the slot is unplugged
+			//Note: this is a file is currently loaded
+			else if (!g_InputRecordingData.ActivePort(sio.port) || sio.slot[sio.port] > 0)
+			{
+				DEVICE_UNPLUGGED();
+				sio.buf[0] = 0x00;
+				siomode = SIO_DUMMY;
+			}
 		}
 #endif
 		break;

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -220,8 +220,8 @@ SIO_WRITE sioWriteController(u8 data)
 			{
 				g_InputRecording.ControllerInterrupt(data, sio.port, sio.slot[sio.port], sio.bufCount, sio.buf);
 			}
-			//If the port isn't in use at all or if the slot for said port is not the first slot, act as if the slot is unplugged
-			//Note: this is a file is currently loaded
+			//If the slot for the current port is not the first slot, act as if the slot is unplugged
+			// -- Only when a file is loaded
 			else if (sio.slot[sio.port] > 0)
 			{
 				DEVICE_UNPLUGGED();

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -222,8 +222,9 @@ SIO_WRITE sioWriteController(u8 data)
 			}
 			//If the port isn't in use at all or if the slot for said port is not the first slot, act as if the slot is unplugged
 			//Note: this is a file is currently loaded
-			else if (!g_InputRecordingData.ActivePort(sio.port) || sio.slot[sio.port] > 0)
+			else if (sio.slot[sio.port] > 0)
 			{
+				recordingConLog(wxString::Format("Y%d-%d\n", sio.port, sio.slot[sio.port]));
 				DEVICE_UNPLUGGED();
 				sio.buf[0] = 0x00;
 				siomode = SIO_DUMMY;

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -195,6 +195,14 @@ enum MenuIdentifiers
 	MenuId_Recording_Editor,
 	MenuId_Recording_VirtualPad_Port0,
 	MenuId_Recording_VirtualPad_Port1,
+	MenuId_Recording_VirtualPad_Port0_1,
+	MenuId_Recording_VirtualPad_Port0_2,
+	MenuId_Recording_VirtualPad_Port0_3,
+	MenuId_Recording_VirtualPad_Port0_4,
+	MenuId_Recording_VirtualPad_Port1_1,
+	MenuId_Recording_VirtualPad_Port1_2,
+	MenuId_Recording_VirtualPad_Port1_3,
+	MenuId_Recording_VirtualPad_Port1_4,
 	MenuId_Recording_Conversions,
 #endif
 
@@ -537,7 +545,7 @@ protected:
 	wxWindowID			m_id_Disassembler;
 
 #ifndef DISABLE_RECORDING
-	wxWindowID			m_id_VirtualPad[2];
+	wxWindowID			m_id_VirtualPad[2][4];
 	wxWindowID			m_id_NewRecordingFrame;
 #endif
 
@@ -566,7 +574,7 @@ public:
 	DisassemblyDialog*	GetDisassemblyPtr() const	{ return (DisassemblyDialog*)wxWindow::FindWindowById(m_id_Disassembler); }
 
 #ifndef DISABLE_RECORDING
-	VirtualPad*			GetVirtualPadPtr(int port) const	{ return (VirtualPad*)wxWindow::FindWindowById(m_id_VirtualPad[port]); }
+	VirtualPad*			GetVirtualPadPtr(u8 port, u8 slot) const	{ return (VirtualPad*)wxWindow::FindWindowById(m_id_VirtualPad[port][slot]); }
 	NewRecordingFrame*	GetNewRecordingFramePtr() const		{ return (NewRecordingFrame*)wxWindow::FindWindowById(m_id_NewRecordingFrame); }
 #endif
 

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -78,13 +78,37 @@ void Pcsx2App::OpenMainFrame()
 	m_id_Disassembler = disassembly->GetId();
 
 #ifndef DISABLE_RECORDING
-	VirtualPad* virtualPad0 = new VirtualPad(mainFrame, wxID_ANY, wxEmptyString, 0);
-	g_InputRecording.SetVirtualPadPtr(virtualPad0, 0);
-	m_id_VirtualPad[0] = virtualPad0->GetId();
-	
-	VirtualPad *virtualPad1 = new VirtualPad(mainFrame, wxID_ANY, wxEmptyString, 1);
-    g_InputRecording.SetVirtualPadPtr(virtualPad1, 1);
-	m_id_VirtualPad[1] = virtualPad1->GetId();
+	VirtualPad* virtualPad0_1 = new VirtualPad(mainFrame, wxID_ANY, wxEmptyString, 0, 0);
+    g_InputRecording.SetVirtualPadPtr(virtualPad0_1, 0, 0);
+    m_id_VirtualPad[0][0] = virtualPad0_1->GetId();
+
+	VirtualPad *virtualPad0_2 = new VirtualPad(mainFrame, wxID_ANY, wxEmptyString, 0, 1);
+    g_InputRecording.SetVirtualPadPtr(virtualPad0_2, 0, 1);
+	m_id_VirtualPad[0][1] = virtualPad0_2->GetId();
+
+    VirtualPad *virtualPad0_3 = new VirtualPad(mainFrame, wxID_ANY, wxEmptyString, 0, 2);
+    g_InputRecording.SetVirtualPadPtr(virtualPad0_3, 0, 2);
+	m_id_VirtualPad[0][2] = virtualPad0_3->GetId();
+
+	VirtualPad *virtualPad0_4 = new VirtualPad(mainFrame, wxID_ANY, wxEmptyString, 0, 3);
+    g_InputRecording.SetVirtualPadPtr(virtualPad0_4, 0, 3);
+	m_id_VirtualPad[0][3] = virtualPad0_4->GetId();
+
+	VirtualPad* virtualPad1_1 = new VirtualPad(mainFrame, wxID_ANY, wxEmptyString, 1, 0);
+	g_InputRecording.SetVirtualPadPtr(virtualPad1_1, 1, 0);
+	m_id_VirtualPad[1][0] = virtualPad1_1->GetId();
+
+    VirtualPad *virtualPad1_2 = new VirtualPad(mainFrame, wxID_ANY, wxEmptyString, 1, 1);
+    g_InputRecording.SetVirtualPadPtr(virtualPad1_2, 1, 1);
+	m_id_VirtualPad[1][1] = virtualPad1_2->GetId();
+
+	VirtualPad *virtualPad1_3 = new VirtualPad(mainFrame, wxID_ANY, wxEmptyString, 1, 2);
+    g_InputRecording.SetVirtualPadPtr(virtualPad1_3, 1, 2);
+	m_id_VirtualPad[1][2] = virtualPad1_3->GetId();
+
+    VirtualPad *virtualPad1_4 = new VirtualPad(mainFrame, wxID_ANY, wxEmptyString, 1, 3);
+    g_InputRecording.SetVirtualPadPtr(virtualPad1_4, 1, 3);
+	m_id_VirtualPad[1][3] = virtualPad1_4->GetId();
 
 	NewRecordingFrame* newRecordingFrame = new NewRecordingFrame(mainFrame);
 	m_id_NewRecordingFrame = newRecordingFrame->GetId();

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -254,8 +254,7 @@ void MainEmuFrame::ConnectMenus()
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_New_Click, this, MenuId_Recording_New);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_Play_Click, this, MenuId_Recording_Play);
 	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_Stop_Click, this, MenuId_Recording_Stop);
-	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_VirtualPad_Open_Click, this, MenuId_Recording_VirtualPad_Port0);
-	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_VirtualPad_Open_Click, this, MenuId_Recording_VirtualPad_Port1);
+	Bind(wxEVT_MENU, &MainEmuFrame::Menu_Recording_VirtualPad_Open_Click, this, MenuId_Recording_VirtualPad_Port0_1, MenuId_Recording_VirtualPad_Port0_1 + 8);
 #endif
 
 	//Bind(wxEVT_MENU, &MainEmuFrame::Menu_Debug_MemoryDump_Click, this, MenuId_Debug_MemoryDump);
@@ -341,7 +340,9 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	, m_menuCapture			( *new wxMenu() )
 	, m_submenuVideoCapture	( *new wxMenu() )
 #ifndef DISABLE_RECORDING
-	, m_menuRecording(*new wxMenu())
+	, m_menuRecording		( *new wxMenu() )
+	, m_submenuvirtualPort0 ( *new wxMenu() )
+	, m_submenuvirtualPort1 ( *new wxMenu() )
 #endif
 	, m_LoadStatesSubmenu( *MakeStatesSubMenu( MenuId_State_Load01, MenuId_State_LoadBackup ) )
 	, m_SaveStatesSubmenu( *MakeStatesSubMenu( MenuId_State_Save01 ) )
@@ -570,8 +571,16 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	m_menuRecording.Append(MenuId_Recording_Stop, _("Stop"))->Enable(false);
 	m_menuRecording.Append(MenuId_Recording_Play, _("Play"));
 	m_menuRecording.AppendSeparator();
-	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port0, _("Virtual Pad (Port 1)"));
-	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port1, _("Virtual Pad (Port 2)"));
+	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port0, _("Virtual Pad (Port 1)"), &m_submenuvirtualPort0);
+	m_menuRecording.Append(MenuId_Recording_VirtualPad_Port1, _("Virtual Pad (Port 2)"), &m_submenuvirtualPort1);
+	m_submenuvirtualPort0.Append(MenuId_Recording_VirtualPad_Port0_1, _("Virtual Pad (Port 1 - Slot 1)"));
+	m_submenuvirtualPort0.Append(MenuId_Recording_VirtualPad_Port0_2, _("Virtual Pad (Port 1 - Slot 2)"))->Enable(g_Conf->EmuOptions.MultitapPort0_Enabled);
+	m_submenuvirtualPort0.Append(MenuId_Recording_VirtualPad_Port0_3, _("Virtual Pad (Port 1 - Slot 3)"))->Enable(g_Conf->EmuOptions.MultitapPort0_Enabled);
+	m_submenuvirtualPort0.Append(MenuId_Recording_VirtualPad_Port0_4, _("Virtual Pad (Port 1 - Slot 4)"))->Enable(g_Conf->EmuOptions.MultitapPort0_Enabled);
+	m_submenuvirtualPort1.Append(MenuId_Recording_VirtualPad_Port1_1, _("Virtual Pad (Port 2 - Slot 1)"));
+	m_submenuvirtualPort1.Append(MenuId_Recording_VirtualPad_Port1_2, _("Virtual Pad (Port 2 - Slot 2)"))->Enable(g_Conf->EmuOptions.MultitapPort1_Enabled);
+	m_submenuvirtualPort1.Append(MenuId_Recording_VirtualPad_Port1_3, _("Virtual Pad (Port 2 - Slot 3)"))->Enable(g_Conf->EmuOptions.MultitapPort1_Enabled);
+	m_submenuvirtualPort1.Append(MenuId_Recording_VirtualPad_Port1_4, _("Virtual Pad (Port 2 - Slot 4)"))->Enable(g_Conf->EmuOptions.MultitapPort1_Enabled);
 #endif
 
 	m_MenuItem_Console.Check( g_Conf->ProgLogBox.Visible );

--- a/pcsx2/gui/MainFrame.h
+++ b/pcsx2/gui/MainFrame.h
@@ -117,6 +117,8 @@ protected:
 
 #ifndef DISABLE_RECORDING
 	wxMenu&			m_menuRecording;
+	wxMenu&			m_submenuvirtualPort0;
+	wxMenu&			m_submenuvirtualPort1;
 #endif
 
 	wxMenu&			m_LoadStatesSubmenu;


### PR DESCRIPTION
Updates the input recording framework to allow for multitap use. Adds new Virtual Pad submenu options to the main Recording drop down list to coincide with an updated Virtual Pad 2D array. 

Incorporates a multitude of safety code in mainmenuclicks to ensure fewer hangups (although probably not all of them).

Updates & optimizes the p2m2 file structure to version 2. Version 2 adds 8 slot values to the header info, rearranges the header info to have all static values printed before dynamic values, and incorporates a direct Pad Count -> File Size relationship (No more having a 2P file size with a 1P TAS). Includes backwards compatibility with version 1 of the official builds.

Note: Currently, the multitap virtual pads will only work if the multitap setting for its port is also active in controller plugin settings. Not 100% sure how to handle that, but that's an issue to save for the future as keeping that option on at all times in plugin settings isn't that big of a deal.

Included: Some examples of the new version of p2m2 files (Played with a slightly altered Gitaroo Man ISO and 100% story mode clear memcard). [Slot Order: 1A 1B 1C 1D 2A 2B 2C 2D]
[Examples.zip](https://github.com/xTVaser/pcsx2-rr/files/4665391/Examples.zip)