### PR TITLE
Additional Frame Handling Fixes

### DIFF
--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -254,7 +254,6 @@ void InputRecording::SetStartingFrame(u32 newStartingFrame)
 
 void InputRecording::Stop()
 {
-	startingFrame = 0;
 	state = InputRecordingMode::NotActive;
 	if (inputRecordingData.Close())
 	{
@@ -298,6 +297,10 @@ void InputRecording::Create(wxString FileName, bool fromSaveState, wxString auth
 		SetStartingFrame(g_FrameCount);
 		recordingConLog(wxString::Format(L"[REC]: Internal Starting Frame: %d\n", startingFrame));
 	}
+	else
+	{
+		SetStartingFrame(0);
+	}
 }
 
 void InputRecording::Play(wxString FileName, bool fromSaveState)
@@ -328,7 +331,12 @@ void InputRecording::Play(wxString FileName, bool fromSaveState)
 		inputRecordingData.Close();
 		return;
 	}
-	savestateInitializing = false;
+
+	if (!g_InputRecording.GetInputRecordingData().FromCurrentFrame())
+	{
+		savestateInitializing = false;
+		SetStartingFrame(0);
+	}
 
 	if (!g_Conf->CurrentIso.IsEmpty())
 	{

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -75,7 +75,7 @@ void SaveStateBase::InputRecordingFreeze()
 				newFrameCounter = 0;
 				recordingConLog(L"[REC]: Warning, you loaded a savestate outside of the bounds of the original recording. This should be avoided. Savestate's framecount has been ignored.\n");
 			}
-			else if (newFrameCounter >= g_InputRecording.GetInputRecordingData().GetMaxFrame())
+			else if (newFrameCounter >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
 			{
 				newFrameCounter = g_InputRecording.GetInputRecordingData().GetMaxFrame();
 				recordingConLog(L"[REC]: Warning, you loaded a savestate outside of the bounds of the original recording. This should be avoided. Savestate's framecount has been ignored.\n");

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -72,8 +72,7 @@ void SaveStateBase::InputRecordingFreeze()
 			// Therefore, the best we can do is limit the frame counter within the min/max of the recording
 			if (newFrameCounter < 0)
 			{
-				newFrameCounter = 0;
-				recordingConLog(L"[REC]: Warning, you loaded a savestate outside of the bounds of the original recording. This should be avoided. Savestate's framecount has been ignored.\n");
+				recordingConLog(L"[REC]: Warning, you loaded a savestate outside of the bounds of the original recording. This should be avoided.\n");
 			}
 			else if (newFrameCounter >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
 			{
@@ -119,7 +118,7 @@ void InputRecording::ControllerInterrupt(u8& data, u8& port, u16& bufCount, u8 b
 			fInterruptFrame = false;
 		}
 	}// We do not want to record or save the first two bytes in the data returned from the PAD plugin
-	else if (fInterruptFrame && bufCount >= 3)
+	else if (fInterruptFrame && bufCount >= 3 && frameCounter >= 0)
 	{
 		// Read or Write
 		if (state == InputRecordingMode::Recording)
@@ -243,6 +242,10 @@ void InputRecording::SetFrameCounter(s32 newFrameCounter)
 void InputRecording::ResetFrameCounter()
 {
 	frameCounter = g_FrameCount - startingFrame;
+	if (frameCounter < 0)
+	{
+		recordingConLog(L"[REC]: Warning, full/fast booting is outside of the bounds of the original recording. This should be avoided.\n");
+	}
 }
 
 void InputRecording::SetStartingFrame(u32 newStartingFrame)

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -239,7 +239,7 @@ void InputRecording::SetFrameCounter(s32 newFrameCounter)
 
 void InputRecording::ResetFrameCounter()
 {
-	frameCounter = g_FrameCount - startingFrame;
+	frameCounter = -startingFrame;
 	if (frameCounter < 0)
 	{
 		recordingConLog(L"[REC]: Warning, full/fast booting places the emulation before frame 0 of the original recording. This should be avoided.\n");

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -156,7 +156,7 @@ u32 InputRecording::GetStartingFrame()
 void InputRecording::IncrementFrameCounter()
 {
 	frameCounter++;
-	if (state == InputRecordingMode::Recording)
+	if (IsRecordingRecording())
 	{
 		GetInputRecordingData().UpdateFrameMax(frameCounter);
 	}
@@ -179,7 +179,12 @@ bool InputRecording::IsSavestateInitializing()
 
 bool InputRecording::IsRecordingReplaying()
 {
-	return IsRecordingActive() && state == InputRecordingMode::Replaying;
+	return state == InputRecordingMode::Replaying;
+}
+
+bool InputRecording::IsRecordingRecording()
+{
+	return state == InputRecordingMode::Recording;
 }
 
 wxString InputRecording::RecordingModeTitleSegment()
@@ -220,7 +225,7 @@ void InputRecording::SavestateInitialized()
 void InputRecording::SetFrameCounter(u32 newFrameCounter)
 {
 	frameCounter = newFrameCounter;
-	if (state == InputRecordingMode::Recording)
+	if (IsRecordingRecording())
 	{
 		GetInputRecordingData().UpdateFrameMax(frameCounter);
 	}

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -47,7 +47,7 @@ void SaveStateBase::InputRecordingFreeze()
 		// TODO - make a function of my own to simplify working with the logging macros
 		recordingConLog(wxString::Format(L"[REC]: Internal Starting Frame: %d\n", g_InputRecording.GetStartingFrame()));
 	}
-	else if (g_InputRecording.IsRecordingActive())
+	else if (g_InputRecording.IsActive())
 	{
 		// Explicitly set the frame change tracking variable as to not
 		// detect loading a savestate as a frame being drawn
@@ -163,7 +163,7 @@ bool InputRecording::IsInterruptFrame()
 	return fInterruptFrame;
 }
 
-bool InputRecording::IsRecordingActive()
+bool InputRecording::IsActive()
 {
 	return state != InputRecordingMode::NotActive;
 }

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -239,7 +239,7 @@ void InputRecording::SetFrameCounter(s32 newFrameCounter)
 
 void InputRecording::ResetFrameCounter()
 {
-	frameCounter = -startingFrame;
+	frameCounter = -(s32)startingFrame;
 	if (frameCounter < 0)
 	{
 		recordingConLog(L"[REC]: Warning, full/fast booting places the emulation before frame 0 of the original recording. This should be avoided.\n");

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -241,6 +241,11 @@ void InputRecording::SetFrameCounter(s32 newFrameCounter)
 	}
 }
 
+void InputRecording::ResetFrameCounter()
+{
+	frameCounter = g_FrameCount - startingFrame;
+}
+
 void InputRecording::SetStartingFrame(u32 newStartingFrame)
 {
 	startingFrame = newStartingFrame;

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -203,17 +203,27 @@ wxString InputRecording::RecordingModeTitleSegment()
 	}
 }
 
+void InputRecording::SetToRecordMode()
+{
+	state = InputRecordingMode::Recording;
+	recordingConLog("[REC]: Record mode ON.\n");
+}
+
+void InputRecording::SetToReplayMode()
+{
+	state = InputRecordingMode::Replaying;
+	recordingConLog("[REC]: Replay mode ON.\n");
+}
+
 void InputRecording::RecordModeToggle()
 {
 	if (state == InputRecordingMode::Replaying)
 	{
-		state = InputRecordingMode::Recording;
-		recordingConLog("[REC]: Record mode ON.\n");
+		SetToRecordMode();
 	}
 	else if (state == InputRecordingMode::Recording)
 	{
-		state = InputRecordingMode::Replaying;
-		recordingConLog("[REC]: Replay mode ON.\n");
+		SetToReplayMode();
 	}
 }
 

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -154,7 +154,7 @@ u32 InputRecording::GetStartingFrame()
 void InputRecording::IncrementFrameCounter()
 {
 	frameCounter++;
-	if (IsRecordingRecording())
+	if (IsRecording())
 	{
 		GetInputRecordingData().UpdateFrameMax(frameCounter);
 	}
@@ -175,12 +175,12 @@ bool InputRecording::IsSavestateInitializing()
 	return savestateInitializing;
 }
 
-bool InputRecording::IsRecordingReplaying()
+bool InputRecording::IsReplaying()
 {
 	return state == InputRecordingMode::Replaying;
 }
 
-bool InputRecording::IsRecordingRecording()
+bool InputRecording::IsRecording()
 {
 	return state == InputRecordingMode::Recording;
 }
@@ -233,7 +233,7 @@ void InputRecording::SavestateInitialized()
 void InputRecording::SetFrameCounter(s32 newFrameCounter)
 {
 	frameCounter = newFrameCounter;
-	if (IsRecordingRecording())
+	if (IsRecording())
 	{
 		GetInputRecordingData().UpdateFrameMax(frameCounter);
 	}
@@ -318,7 +318,9 @@ void InputRecording::Play(wxString FileName, bool fromSaveState)
 	{
 		return;
 	}
-	// TODO: use an explicit function for loading the savestate that accompanies a recording file.
+	// TODO: add an explicit function that handles loading a TAS file
+	// from frame 0 - whether that be through fast/full boot
+	// or from a base savestate.
 
 	// For if a savestate is loaded - otherwise, starting frame would be misassigned
 	savestateInitializing = true;

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -72,12 +72,12 @@ void SaveStateBase::InputRecordingFreeze()
 			// Therefore, the best we can do is limit the frame counter within the min/max of the recording
 			if (newFrameCounter < 0)
 			{
-				recordingConLog(L"[REC]: Warning, you loaded a savestate outside of the bounds of the original recording. This should be avoided.\n");
+				recordingConLog(L"[REC]: Warning, you loaded a savestate placed before frame 0 of the original recording. This should be avoided.\n");
 			}
 			else if (newFrameCounter >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
 			{
 				newFrameCounter = g_InputRecording.GetInputRecordingData().GetMaxFrame();
-				recordingConLog(L"[REC]: Warning, you loaded a savestate outside of the bounds of the original recording. This should be avoided. Savestate's framecount has been ignored.\n");
+				recordingConLog(L"[REC]: Warning, you loaded a savestate past the bounds of the original recording. This should be avoided. Savestate's framecount has been ignored.\n");
 			}
 			g_InputRecording.SetFrameCounter(newFrameCounter);
 		}
@@ -244,7 +244,7 @@ void InputRecording::ResetFrameCounter()
 	frameCounter = g_FrameCount - startingFrame;
 	if (frameCounter < 0)
 	{
-		recordingConLog(L"[REC]: Warning, full/fast booting is outside of the bounds of the original recording. This should be avoided.\n");
+		recordingConLog(L"[REC]: Warning, full/fast booting places the emulation before frame 0 of the original recording. This should be avoided.\n");
 	}
 }
 

--- a/pcsx2/Recording/InputRecording.cpp
+++ b/pcsx2/Recording/InputRecording.cpp
@@ -55,7 +55,7 @@ void SaveStateBase::InputRecordingFreeze()
 			g_InputRecording.GetInputRecordingData().AddUndoCount();
 			// Reloading a save-state means the internal recording frame counter may need to be adjusted
 			// Since we persist the g_FrameCount of the beginning of the movie, we can use it to recalculate it
-			u32 newFrameCounter = g_FrameCount - (g_InputRecording.GetStartingFrame());
+			s32 newFrameCounter = g_FrameCount - (g_InputRecording.GetStartingFrame());
 			// It is possible for someone to load a savestate outside of the original recording's context
 			// this should be avoided (hence the log) but I don't think there is a mechanism to reverse loading
 			// the save-state
@@ -138,7 +138,7 @@ void InputRecording::ControllerInterrupt(u8& data, u8& port, u16& bufCount, u8 b
 	}
 }
 
-u32 InputRecording::GetFrameCounter()
+s32 InputRecording::GetFrameCounter()
 {
 	return frameCounter;
 }
@@ -232,7 +232,7 @@ void InputRecording::SavestateInitialized()
 	savestateInitializing = false;
 }
 
-void InputRecording::SetFrameCounter(u32 newFrameCounter)
+void InputRecording::SetFrameCounter(s32 newFrameCounter)
 {
 	frameCounter = newFrameCounter;
 	if (IsRecordingRecording())

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -41,7 +41,7 @@ public:
 	bool IsInterruptFrame();
 
 	// If there is currently an input recording being played back or actively being recorded
-	bool IsRecordingActive();
+	bool IsActive();
 
 	// Whether or not the recording's initial save state has yet to be loaded or saved and 
 	// the rest of the recording can be initialized

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -27,7 +27,7 @@ public:
 	void ControllerInterrupt(u8 &data, u8 &port, u16 &BufCount, u8 buf[]);
 
 	// The running frame counter for the input recording
-	u32 GetFrameCounter();
+	s32 GetFrameCounter();
 
 	InputRecordingFile &GetInputRecordingData();
 
@@ -70,7 +70,7 @@ public:
 	void SavestateInitialized();
 
 	// Set the running frame counter for the input recording to an arbitrary value
-	void SetFrameCounter(u32 newFrameCounter);
+	void SetFrameCounter(s32 newFrameCounter);
 
 	// Store the starting internal PCSX2 g_FrameCount value
 	void SetStartingFrame(u32 newStartingFrame);
@@ -94,7 +94,7 @@ private:
 
 	// DEPRECATED: Slated for removal 
 	bool fInterruptFrame = false;
-	u32 frameCounter = 0;
+	s32 frameCounter = 0;
 	InputRecordingFile inputRecordingData;
 	bool savestateInitializing = false;
 	u32 startingFrame = 0;

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -57,6 +57,12 @@ public:
 	// String representation of the current recording mode to be interpolated into the title
 	wxString RecordingModeTitleSegment();
 
+	// Sets input recording to Record Mode
+	void SetToRecordMode();
+
+	// Sets input recording to Replay Mode
+	void SetToReplayMode();
+
 	// Switches between recording and replaying the active input recording file
 	void RecordModeToggle();
 

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -49,10 +49,10 @@ public:
 	bool IsSavestateInitializing();
 
 	// If there is currently an input recording being played back
-	bool IsRecordingReplaying();
+	bool IsReplaying();
 
 	// If there is currently an input recording being recorded
-	bool IsRecordingRecording();
+	bool IsRecording();
 
 	// String representation of the current recording mode to be interpolated into the title
 	wxString RecordingModeTitleSegment();

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -72,6 +72,10 @@ public:
 	// Set the running frame counter for the input recording to an arbitrary value
 	void SetFrameCounter(s32 newFrameCounter);
 
+	// Set the running frame counter for the input recording to the displacement
+	// from a full/fast boot using g_framecount
+	void ResetFrameCounter();
+
 	// Store the starting internal PCSX2 g_FrameCount value
 	void SetStartingFrame(u32 newStartingFrame);
 	

--- a/pcsx2/Recording/InputRecording.h
+++ b/pcsx2/Recording/InputRecording.h
@@ -51,6 +51,9 @@ public:
 	// If there is currently an input recording being played back
 	bool IsRecordingReplaying();
 
+	// If there is currently an input recording being recorded
+	bool IsRecordingRecording();
+
 	// String representation of the current recording mode to be interpolated into the title
 	wxString RecordingModeTitleSegment();
 

--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -88,7 +88,7 @@ void InputRecordingControls::FrameAdvance()
 {
 	if (g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetMaxFrame())
 	{
-		g_InputRecording.RecordModeToggle();
+		g_InputRecording.SetToRecordMode();
 		return;
 	}
 	frameAdvanceMarker = g_InputRecording.GetFrameCounter();
@@ -125,7 +125,7 @@ void InputRecordingControls::Resume()
 {
 	if (g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetMaxFrame())
 	{
-		g_InputRecording.RecordModeToggle();
+		g_InputRecording.SetToRecordMode();
 		return;
 	}
 	pauseEmulation = false;
@@ -141,7 +141,7 @@ void InputRecordingControls::TogglePause()
 {
 	if (pauseEmulation && g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetMaxFrame())
 	{
-		g_InputRecording.RecordModeToggle();
+		g_InputRecording.SetToRecordMode();
 		return;
 	}
 	pauseEmulation = !pauseEmulation;

--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -54,7 +54,7 @@ void InputRecordingControls::HandleFrameAdvanceAndPausing()
 		return;
 	}
 
-	if (g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetMaxFrame())
+	if (g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
 	{
 		pauseEmulation = true;
 	}
@@ -86,7 +86,7 @@ void InputRecordingControls::ResumeCoreThreadIfStarted()
 
 void InputRecordingControls::FrameAdvance()
 {
-	if (g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetMaxFrame())
+	if (g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
 	{
 		g_InputRecording.SetToRecordMode();
 		return;
@@ -123,7 +123,7 @@ void InputRecordingControls::PauseImmediately()
 
 void InputRecordingControls::Resume()
 {
-	if (g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetMaxFrame())
+	if (g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
 	{
 		g_InputRecording.SetToRecordMode();
 		return;
@@ -139,7 +139,7 @@ void InputRecordingControls::SetFrameCountTracker(u32 newFrame)
 
 void InputRecordingControls::TogglePause()
 {
-	if (pauseEmulation && g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= g_InputRecording.GetInputRecordingData().GetMaxFrame())
+	if (pauseEmulation && g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
 	{
 		g_InputRecording.SetToRecordMode();
 		return;

--- a/pcsx2/Recording/InputRecordingControls.cpp
+++ b/pcsx2/Recording/InputRecordingControls.cpp
@@ -54,7 +54,7 @@ void InputRecordingControls::HandleFrameAdvanceAndPausing()
 		return;
 	}
 
-	if (g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
+	if (g_InputRecording.IsReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
 	{
 		pauseEmulation = true;
 	}
@@ -86,7 +86,7 @@ void InputRecordingControls::ResumeCoreThreadIfStarted()
 
 void InputRecordingControls::FrameAdvance()
 {
-	if (g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
+	if (g_InputRecording.IsReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
 	{
 		g_InputRecording.SetToRecordMode();
 		return;
@@ -123,7 +123,7 @@ void InputRecordingControls::PauseImmediately()
 
 void InputRecordingControls::Resume()
 {
-	if (g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
+	if (g_InputRecording.IsReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
 	{
 		g_InputRecording.SetToRecordMode();
 		return;
@@ -139,7 +139,7 @@ void InputRecordingControls::SetFrameCountTracker(u32 newFrame)
 
 void InputRecordingControls::TogglePause()
 {
-	if (pauseEmulation && g_InputRecording.IsRecordingReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
+	if (pauseEmulation && g_InputRecording.IsReplaying() && g_InputRecording.GetFrameCounter() >= (s32)g_InputRecording.GetInputRecordingData().GetMaxFrame())
 	{
 		g_InputRecording.SetToRecordMode();
 		return;

--- a/pcsx2/Recording/InputRecordingControls.h
+++ b/pcsx2/Recording/InputRecordingControls.h
@@ -59,7 +59,7 @@ private:
 	// and should be cleared once a single frame has passed
 	bool frameAdvancing = false;
 	// The input recording frame that frame advancing began on
-	u32 frameAdvanceMarker = 0;
+	s32 frameAdvanceMarker = 0;
 	// Used to detect if the internal PCSX2 g_FrameCount has changed
 	u32 frameCountTracker = -1;
 	// Indicates if we intend to call CoreThread.PauseSelf() on the current or next available vsync

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -335,9 +335,9 @@ bool InputRecordingFile::WriteMaxFrame()
 	return true;
 }
 
-void InputRecordingFile::UpdateFrameMax(unsigned long frame)
+void InputRecordingFile::UpdateFrameMax(long frame)
 {
-	if (recordingFile == NULL || totalFrames >= frame)
+	if (recordingFile == NULL || (long)totalFrames >= frame)
 	{
 		return;
 	}

--- a/pcsx2/Recording/InputRecordingFile.cpp
+++ b/pcsx2/Recording/InputRecordingFile.cpp
@@ -293,6 +293,9 @@ bool InputRecordingFile::ReadHeaderAndCheck()
 	}
 	else
 	{
+		// TODO: Specify in a recording whether to use Fast or Full boot
+		// Differing number of frames to deal with even tho they both start
+		// with a g_framecount of 0 (I believe anyways)
 		sApp.SysExecute();
 	}
 

--- a/pcsx2/Recording/InputRecordingFile.h
+++ b/pcsx2/Recording/InputRecordingFile.h
@@ -73,7 +73,7 @@ public:
 	bool WriteSaveState();
 
 	bool ReadHeaderAndCheck();
-	void UpdateFrameMax(unsigned long frame);
+	void UpdateFrameMax(long frame);
 	void AddUndoCount();
 
 	unsigned long recordingFrameCounter = 0;

--- a/pcsx2/Sio.cpp
+++ b/pcsx2/Sio.cpp
@@ -218,13 +218,16 @@ SIO_WRITE sioWriteController(u8 data)
 #ifndef DISABLE_RECORDING
 		if (g_Conf->EmuOptions.EnableRecordingTools)
 		{
-			g_InputRecording.ControllerInterrupt(data, sio.port, sio.bufCount, sio.buf);
-			if (g_InputRecording.IsInterruptFrame())
+			// Ensures that only controllers 1 & 2 are polled
+			if (sio.slot[sio.port] == 0)
 			{
-				g_RecordingInput.ControllerInterrupt(data, sio.port, sio.bufCount, sio.buf);
+				g_InputRecording.ControllerInterrupt(data, sio.port, sio.bufCount, sio.buf);
+				if (g_InputRecording.IsInterruptFrame())
+				{
+					g_RecordingInput.ControllerInterrupt(data, sio.port, sio.bufCount, sio.buf);
+				}
+				PadData::LogPadData(sio.port, sio.bufCount, sio.buf);
 			}
-
-			PadData::LogPadData(sio.port, sio.bufCount, sio.buf);
 		}
 #endif
 		break;

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1145,7 +1145,7 @@ void Pcsx2App::SysExecute()
 {
 	SysExecutorThread.PostEvent( new SysExecEvent_Execute() );
 #ifndef DISABLE_RECORDING
-	if (g_Conf->EmuOptions.EnableRecordingTools && g_InputRecording.IsRecordingActive())
+	if (g_InputRecording.IsActive())
 	{
 		g_InputRecording.ResetFrameCounter();
 	}
@@ -1159,7 +1159,7 @@ void Pcsx2App::SysExecute( CDVD_SourceType cdvdsrc, const wxString& elf_override
 {
 	SysExecutorThread.PostEvent( new SysExecEvent_Execute(cdvdsrc, elf_override) );
 #ifndef DISABLE_RECORDING
-	if (g_Conf->EmuOptions.EnableRecordingTools && g_InputRecording.IsRecordingActive())
+	if ( g_InputRecording.IsActive())
 	{
 		g_InputRecording.ResetFrameCounter();
 	}

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1144,6 +1144,12 @@ protected:
 void Pcsx2App::SysExecute()
 {
 	SysExecutorThread.PostEvent( new SysExecEvent_Execute() );
+#ifndef DISABLE_RECORDING
+	if (g_Conf->EmuOptions.EnableRecordingTools && g_InputRecording.IsRecordingActive())
+	{
+		g_InputRecording.ResetFrameCounter();
+	}
+#endif
 }
 
 // Executes the specified cdvd source and optional elf file.  This command performs a

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1147,7 +1147,17 @@ void Pcsx2App::SysExecute()
 #ifndef DISABLE_RECORDING
 	if (g_InputRecording.IsActive())
 	{
-		g_InputRecording.ResetFrameCounter();
+		// Forces inputRecording to wait for a confirmed pause before resetting
+		// frameCounter to the proper value. Ensures that any lingering emulation
+		// before the full/fast boot doesn't increment the already reset value
+		if (!g_InputRecordingControls.isEmulationAndRecordingPaused())
+		{
+			g_InputRecordingControls.Pause();
+			g_InputRecording.ResetFrameCounter();
+			g_InputRecordingControls.Resume();
+		}
+		else
+			g_InputRecording.ResetFrameCounter();
 	}
 #endif
 }
@@ -1161,7 +1171,17 @@ void Pcsx2App::SysExecute( CDVD_SourceType cdvdsrc, const wxString& elf_override
 #ifndef DISABLE_RECORDING
 	if ( g_InputRecording.IsActive())
 	{
-		g_InputRecording.ResetFrameCounter();
+		// Forces inputRecording to wait for a confirmed pause before resetting
+		// frameCounter to the proper value. Ensures that any lingering emulation
+		// before the full/fast boot doesn't increment the already reset value
+		if (!g_InputRecordingControls.isEmulationAndRecordingPaused())
+		{
+			g_InputRecordingControls.Pause();
+			g_InputRecording.ResetFrameCounter();
+			g_InputRecordingControls.Resume();
+		}
+		else
+			g_InputRecording.ResetFrameCounter();
 	}
 #endif
 }

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1158,6 +1158,12 @@ void Pcsx2App::SysExecute()
 void Pcsx2App::SysExecute( CDVD_SourceType cdvdsrc, const wxString& elf_override )
 {
 	SysExecutorThread.PostEvent( new SysExecEvent_Execute(cdvdsrc, elf_override) );
+#ifndef DISABLE_RECORDING
+	if (g_Conf->EmuOptions.EnableRecordingTools && g_InputRecording.IsRecordingActive())
+	{
+		g_InputRecording.ResetFrameCounter();
+	}
+#endif
 }
 
 // Returns true if there is a "valid" virtual machine state from the user's perspective.  This

--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -732,7 +732,7 @@ void GSFrame::OnUpdateTitle( wxTimerEvent& evt )
 #ifndef DISABLE_RECORDING
 	wxString title;
 	wxString movieMode;
-	if (g_InputRecording.IsRecordingActive()) 
+	if (g_InputRecording.IsActive()) 
 	{
 		title = templates.RecordingTemplate;
 		title.Replace(L"${frame}", pxsFmt(L"%d", g_InputRecording.GetFrameCounter() + 1)); // zero based


### PR DESCRIPTION
**Addresses some issue I encountered with this branch:**
Originally, calling a full/fast boot would not properly reset the frameCounter to the proper displacement. This meant said frameCounter continually incremented starting from where it was left off. To solve this, I added a reset function that gets called on emulation reset. It should always reset frameCounter to the proper value.

Made frameCounter a signed value to add the ability to handle frames < 0 & frames > totalFrames differently. While it is true that it should be easy to add frames after the end point of a recording, it should be impossible to add frames before the start. Therefore, I made it so recording/replaying is halted for anything before the first frame of inputs.

Other reorganizations and an additional slot check to ensure that only pads 1A & 2A are being polled for recording or playback.