### PR TITLE
pcsx2-gui: Disable Menu Options on GS close

### DIFF
--- a/pcsx2/gui/AppCorePlugins.cpp
+++ b/pcsx2/gui/AppCorePlugins.cpp
@@ -370,7 +370,7 @@ bool AppCorePlugins::OpenPlugin_GS()
 void AppCorePlugins::ClosePlugin_GS()
 {
 	_parent::ClosePlugin_GS();
-	if( CloseViewportWithPlugins && GetMTGS().IsSelf() && GSopen2 ) sApp.CloseGsPanel();
+	if( GetMTGS().IsSelf() && GSopen2 ) sApp.CloseGsPanel();
 }
 
 

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -1038,6 +1038,12 @@ void Pcsx2App::CloseGsPanel()
 		if (GSPanel* woot = gsFrame->GetViewport())
 			woot->Destroy();
 	}
+#ifndef DISABLE_RECORDING
+	// Disable recording controls that only make sense if the game is running
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_FrameAdvance, false);
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_TogglePause, false);
+	sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, false);
+#endif
 }
 
 void Pcsx2App::OnGsFrameClosed( wxWindowID id )
@@ -1052,15 +1058,6 @@ void Pcsx2App::OnGsFrameClosed( wxWindowID id )
 		// right now there's no way to resume from suspend without GUI.
 		PrepForExit();
 	}
-#ifndef DISABLE_RECORDING
-	else
-	{
-		// Disable recording controls that only make sense if the game is running
-		sMainFrame.enableRecordingMenuItem(MenuId_Recording_FrameAdvance, false);
-		sMainFrame.enableRecordingMenuItem(MenuId_Recording_TogglePause, false);
-		sMainFrame.enableRecordingMenuItem(MenuId_Recording_ToggleRecordingMode, false);
-	}
-#endif
 }
 
 void Pcsx2App::OnProgramLogClosed( wxWindowID id )


### PR DESCRIPTION
Also, now that there's a reason for it, enable the call to the CloseGSPanel function (although it still can't delete the panel).

Note: A squash to combine this with your older commit for enabling and disabling would probably be good.