### PR TITLE
recording: Log "Recording" > "Input Recording" consistency

### DIFF
--- a/pcsx2/gui/FrameForGS.cpp
+++ b/pcsx2/gui/FrameForGS.cpp
@@ -142,14 +142,14 @@ void GSPanel::InitRecordingAccelerators()
 		m_Accels->findKeycodeWithCommandId("InputRecordingModeToggle").toTitleizedString(),
 		g_InputRecording.IsActive());
 
-	recordingConLog(L"Initialized Recording Key Bindings\n");
+	recordingConLog(L"Initialized Input Recording Key Bindings\n");
 }
 
 void GSPanel::RemoveRecordingAccelerators()
 {
 	m_Accels.reset(new AcceleratorDictionary);
 	InitDefaultAccelerators();
-	recordingConLog(L"Disabled Recording Key Bindings\n");
+	recordingConLog(L"Disabled Input Recording Key Bindings\n");
 }
 #endif
 


### PR DESCRIPTION
Just a log change to match other recent naming convention changes regard input recording.
