### PR TITLE
Add patch for Jak II PAL build

### DIFF
--- a/bin/cheats/2479F4A9.pnach
+++ b/bin/cheats/2479F4A9.pnach
@@ -1,0 +1,20 @@
+gametitle=Jak II: Renegade - (PAL-M7)(SCES-51608)
+comment=Enables Developer/Debug Mode - Credit to water111 for discovering / documenting the required ELF edits
+comment=Credits to Luminar Light for making the patch for this game build.
+
+// NOP Disabling MasterDebug
+patch=0,EE,001003f8,word,00000000
+// NOP Disabling DebugSegment
+patch=0,EE,00100400,word,00000000
+// NOP SendFromBufferD call in InitListener - This is called only when MasterDebug is on
+patch=0,EE,00108d88,word,00000000
+
+// 0x4ff0000 for global heap initialization - Set in InitMachine
+patch=0,EE,00103364,word,3c0604ff
+
+// This is about changing the stack pointer
+// Shoves a MIPS instruction into near the very top of the entry point
+// Ghidra blows up here, but binary ninja can handle it
+// Orginally at this position there is `2D E8 40 00` - `daddu $sp, $v0, $zero`
+// This changes it to - `lui sp, 0x0800` Which loads the value 0x0800 to the stackpointer register, modifying it.
+patch=0,EE,0010017c,word,3c1d0800


### PR DESCRIPTION
Added a pnach file for Jak II PAL build. It was based on the pnach of the NTSC version. Tested it, it works fine.