### PR TITLE
Add patch for Jak II NTSC-J

### DIFF
--- a/bin/cheats/B4976DAF.pnach
+++ b/bin/cheats/B4976DAF.pnach
@@ -1,0 +1,25 @@
+gametitle=Jak II - (NTSC-J)(SCPS-15057)
+comment=Enables Developer/Debug Mode - Credit to water111 for discovering / documenting the required ELF edits
+
+// NOP Disabling MasterDebug
+patch=0,EE,001003f8,word,00000000
+// NOP Disabling DebugSegment
+patch=0,EE,00100400,word,00000000
+// NOP SendFromBufferD call in InitListener - This is called only when MasterDebug is on
+patch=0,EE,00108cd0,word,00000000
+
+// 0x4ff0000 for global heap initialization - Set in InitMachine
+patch=0,EE,001032bc,word,3c0604ff
+
+// This is about changing the stack pointer
+// Shoves a MIPS instruction into near the very top of the entry point
+// Ghidra blows up here, but binary ninja can handle it
+// Orginally at this position there is `2D E8 40 00` - `daddu $sp, $v0, $zero`
+// This changes it to - `lui sp, 0x0800` Which loads the value 0x0800 to the stackpointer register, modifying it.
+patch=0,EE,0010017c,word,3c1d0800
+
+// Example - Changing the Starting Level, Disabled by Default
+// Load halfpipe level by default - "halfpipe" BigEndian - 68 61 6c 66 | 70 69 70 65
+// LittleEndian:
+//patch=0,EE,00127f10,word,666C6168
+//patch=0,EE,00127f14,word,65706970


### PR DESCRIPTION
I remembered that water's Jak 2 debug build supported NTSC-J, even though he never tested it with that build. The Japanese ELF has some differences compared to NTSC ELF, but it is close enough... so the exact same patches work.