### PR TITLE
Add documentation for Jak and Daxter Debug Modes

### DIFF
--- a/bin/cheats/A2034C69.pnach
+++ b/bin/cheats/A2034C69.pnach
@@ -1,0 +1,36 @@
+gametitle=Jak II [Demo] - (U)(SCUS-97273)
+comment=Enables Developer/Debug Mode - Credit to water111 and Vaser for discovering / documenting the required ELF edits for the Jak 2 Demo. 
+comment=Thanks to Luminar Light for patching and documenting the required level loading patches.
+comment=When the game boots, you will see a "work in progress" splash screen, followed by a black screen. The game is running in the background. 
+comment=When the screen is black, press L3 + Select, and then press X. Then, use the continue feature from the debug menu to "escape" the missing fortress level.
+
+// NOP Disabling MasterDebug
+patch=0,EE,001002ec,word,00000000
+// NOP Disabling DebugSegment
+patch=0,EE,001002f4,word,00000000
+// NOP SendFromBufferD call in InitListener - This is called only when MasterDebug is on
+patch=0,EE,00108660,word,00000000
+
+// 0x4ff0000 for global heap initialization - Set in InitMachine
+patch=0,EE,00102fac,word,3c0604ff
+
+// This is about changing the stack pointer
+// Shoves a MIPS instruction into near the very top of the entry point
+// Ghidra blows up here, but binary ninja can handle it
+// Orginally at this position there is `2D E8 40 00` - `daddu $sp, $v0, $zero`
+// This changes it to - `lui sp, 0x0800` Which loads the value 0x0800 to the stackpointer register, modifying it.
+patch=0,EE,00100068,word,3c1d0800
+
+// This disables a couple of different demo flags
+patch=0,EE,00100298,word,00000000
+patch=0,EE,001002a4,word,00000000
+
+// This changes the DebugBootMessage from `demo` to `play`.
+patch=0,EE,00126e10,word,79616c70
+
+// This solves an issue caused by changing the DebugBootMessage
+// The level loading system is patched to load `demo` and `demo-vis` instead of `fea` and `forexita-vis`.
+// By doing this, you avoid a softlock at the start of the game
+patch=1,EE,0077BB18,word,6f6d6564 
+patch=1,EE,0077C938,word,6d6d6564 
+patch=1,EE,0077C93C,word,7369762d

--- a/docs/JakReadme.md
+++ b/docs/JakReadme.md
@@ -1,0 +1,26 @@
+Allows you to access Debug Mode in most of the publicly available Jak and Daxter builds.
+
+This is a modified PCSX2 build that more closely emulates a PS2 TOOL (devkit), allowing the games' Debug Mode to load. It uses pnach files to patch the game (located in cheats folder). This build will work for any game / setup that requires a devkit-like setup. It is not specific to just 1 game. Support has recently been expanded to PAL/NTSC-J versions of the Jak and Daxter Trilogy, as well as several prototypes and demos.
+
+Usage:
+
+    Cheats must be enabled for Debug Mode to work. You can enable cheats here: PCSX2 -> Game Settings -> Enable Cheats
+
+    For retail and demo builds, just select the ISO and boot. You can do it with or without fast boot, but doing without is recommended - the game will be set to Japanese otherwise.
+    For internal/preview/review builds, you must unpack the ISO of the build. Select the ISO, and then choose Run ELF:
+        For Jak II, you must choose FIREWIRE.IRX from the DRIVERS folder of the build.
+        For Jak 3, you must choose DISKINFO.BIN from the root directory of the build.
+    There will be significant visual glitches in these builds until you enable manual game-fixes:
+        Go to PCSX2 -> Emulation Settings -> Game Fixes
+        Check "Enable manual game fixes" and then check "VU0 Kickstart to avoid sync problems with VU1".
+
+Troubleshooting:
+
+    If a build doesn't boot into Debug Mode, then make sure that you followed the Usage section properly.
+    Graphical issues? Double check that "VU0 Kickstart to avoid sync problems with VU1" is enabled in PCSX2 -> Emulation Settings -> Game Fixes
+    When loading the game, you should see logs similar to the following:
+
+Found Cheats file: '9184AAF1.pnach'
+comment: Enables Developer/Debug Mode - Credit to water111 for discovering / documenting the required ELF edits
+Loaded 5 Cheats from '9184AAF1.pnach' at 'C:\Users\xtvas\Repositories\pcsx2\bin\cheats'
+Overall 5 Cheats loaded

--- a/pcsx2/gui/MainFrame.cpp
+++ b/pcsx2/gui/MainFrame.cpp
@@ -576,7 +576,7 @@ MainEmuFrame::MainEmuFrame(wxWindow* parent, const wxString& title)
 	// background logo size, which is what it'll eventually be resized to.
 	wxSize backsize(m_background->GetBitmap().GetWidth(), m_background->GetBitmap().GetHeight());
 
-	wxString wintitle = "PCSX2 - Jak and Daxter Debug Mode";
+	wxString wintitle = "PCSX2 - 128MB Build";
 	SetTitle( wintitle );
 
 	// Ideally the __WXMSW__ port should use the embedded IDI_ICON2 icon, because wxWidgets sucks and


### PR DESCRIPTION
Adds a brief readme on usage and troubleshooting to be linked on the JakSpeedruns download page.