### PR TITLE
delete networking and make console output work

### DIFF
--- a/bin/cheats/12804727.pnach
+++ b/bin/cheats/12804727.pnach
@@ -2,6 +2,11 @@ gametitle=Jak 3 - (PAL-M7)(SCES-52460)
 comment=Enables Developer/Debug Mode - Credit to water111 for discovering / documenting the required ELF edits in Jak 1/2.  ELF edits for Jak 3 figured out by xTVaser.
 comment=Credits to Luminar Light for making the patch for this game build.
 
+// nop sceResetttyinit call
+patch=0,EE,00125F10,word,00000000
+// nop InitGoalProto call
+patch=0,EE,00103808,word,00000000
+
 // NOP Disabling MasterDebug
 patch=0,EE,00100404,word,00000000
 // NOP Disabling DebugSegment

--- a/bin/cheats/9C712FF0.pnach
+++ b/bin/cheats/9C712FF0.pnach
@@ -6,3 +6,9 @@ comment=Credits to Luminar Light for making the patch for this game build.
 patch=0,EE,00100290,word,00000000
 // NOP Disabling MasterDebug
 patch=0,EE,0010029c,word,00000000
+
+// NOP InitGoalProto & sceResetttyinit calls
+patch=0,EE,0012ac70,word,00000000
+patch=0,EE,00103e74,word,00000000
+// redirect format output: #t to 0
+patch=0,EE,00102db4,word,10000013


### PR DESCRIPTION
Extra patches for Jak 1 PAL and Jak 3 PAL, kills off the networking completely and redirects REPL output to the tty console instead. (I hope I did this right.)